### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
   // Handle ESC key
   useEffect(() => {
     let escCount = 0;
-    let escTimer: NodeJS.Timeout;
+    let escTimer: ReturnType<typeof setTimeout>;
 
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/src/components/ExcelImport.tsx
+++ b/src/components/ExcelImport.tsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import * as XLSX from 'xlsx';
 import { motion } from 'framer-motion';
-import { FaFileExcel, FaCheck, FaTimes } from 'react-icons/fa';
+import { FaFileExcel, FaCheck } from 'react-icons/fa';
 import toast from 'react-hot-toast';
 import { useStore } from '../store/useStore';
-import { Client } from '../types';
+// import type as needed
 
 interface ExcelImportProps {
   onClose: () => void;
@@ -28,7 +28,7 @@ export const ExcelImport: React.FC<ExcelImportProps> = ({ onClose, onImportCompl
       const workbook = XLSX.read(arrayBuffer);
       const sheetName = workbook.SheetNames[0];
       const worksheet = workbook.Sheets[sheetName];
-      const data = XLSX.utils.sheet_to_json(worksheet);
+      const data = XLSX.utils.sheet_to_json<Record<string, unknown>>(worksheet);
       
       if (data.length === 0) {
         toast.error('הקובץ ריק או לא מכיל נתונים תקינים');
@@ -39,7 +39,7 @@ export const ExcelImport: React.FC<ExcelImportProps> = ({ onClose, onImportCompl
       setPreviewData(data.slice(0, 5)); // Preview first 5 rows
       
       // Extract headers
-      const firstRow = data[0];
+      const firstRow = data[0] as Record<string, unknown>;
       const extractedHeaders = Object.keys(firstRow);
       setHeaders(extractedHeaders);
       
@@ -101,9 +101,6 @@ export const ExcelImport: React.FC<ExcelImportProps> = ({ onClose, onImportCompl
         if (!name) return; // Skip rows without name
         
         // Create client with mapped fields
-        const hourlyRateHeader = Object.keys(mappings).find(key => mappings[key] === 'hourlyRate');
-        const hourlyRate = hourlyRateHeader ? Number(row[hourlyRateHeader]) || undefined : undefined;
-        
         addClient(name);
         importedCount++;
       });

--- a/src/components/Table/ClientTable.tsx
+++ b/src/components/Table/ClientTable.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { FaEdit, FaTrash, FaCheck, FaTimes, FaEllipsisV } from 'react-icons/fa';
+import React, { useState, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { FaEdit, FaTrash, FaCheck, FaTimes } from 'react-icons/fa';
 import { useStore } from '../../store/useStore';
 import toast from 'react-hot-toast';
-import { TableColumn } from '../../types';
 
 interface ClientTableProps {
   tableId: string;
@@ -14,7 +13,6 @@ export const ClientTable: React.FC<ClientTableProps> = ({ tableId }) => {
     clients,
     tables,
     timeEntries,
-    addClient,
     updateClient,
     deleteClient,
     updateTable,
@@ -111,7 +109,7 @@ export const ClientTable: React.FC<ClientTableProps> = ({ tableId }) => {
   };
 
   // Get cell value
-  const getCellValue = (clientId: string, columnId: string) => {
+  const getCellValue = (clientId: string, columnId: string): string => {
     if (currentTable.type === 'timeTracking') {
       if (columnId === 'total') {
         const client = clients.find(c => c.id === clientId);
@@ -120,7 +118,7 @@ export const ClientTable: React.FC<ClientTableProps> = ({ tableId }) => {
       return getClientHours(clientId, columnId);
     } else {
       const row = currentTable.rows.find(r => r.clientId === clientId);
-      return row?.[columnId] || '';
+      return row && row[columnId] !== undefined ? String(row[columnId]) : '';
     }
   };
 

--- a/src/components/TableSelector.tsx
+++ b/src/components/TableSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FaPlus, FaTable, FaFileExcel, FaEdit, FaTrash } from 'react-icons/fa';
+import { FaPlus, FaTable, FaFileExcel, FaTrash } from 'react-icons/fa';
 import { useStore } from '../store/useStore';
 import toast from 'react-hot-toast';
 import { ExcelImportTable } from './ExcelImportTable';

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -20,7 +20,7 @@ export const Timer: React.FC = () => {
 
   // Update elapsed time every second
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval>;
 
     if (timerState.isRunning && timerState.startTime) {
       interval = setInterval(() => {
@@ -61,12 +61,12 @@ export const Timer: React.FC = () => {
 
   const handlePause = () => {
     pauseTimer();
-    toast.info('הטיימר הושהה');
+    toast('הטיימר הושהה');
   };
 
   const handleResume = () => {
     resumeTimer();
-    toast.info('הטיימר ממשיך');
+    toast('הטיימר ממשיך');
   };
 
   const currentClient = clients.find(


### PR DESCRIPTION
## Summary
- clean up unused imports in client table and table selector
- refine Excel import logic and generics
- handle timer pause/resume toasts and interval type
- use setTimeout type for escape timer in App

## Testing
- `npm run build`
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68646fe190bc83219cf93634c94f0edc