### PR TITLE
Create local PDF reader layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { type ChangeEvent, type DragEvent, useEffect, useMemo, useState } from 'react';
 
 const MAX_FILE_SIZE_MB = 50;
 
 function App() {
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState('');
+  const [isDragActive, setIsDragActive] = useState(false);
 
   const fileUrl = useMemo(() => {
     if (!file) {
@@ -27,8 +28,7 @@ function App() {
     };
   }, [fileUrl]);
 
-  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const selected = event.target.files?.[0];
+  const validateAndSetFile = (selected: File | undefined) => {
     setError('');
 
     if (!selected) {
@@ -51,6 +51,27 @@ function App() {
     }
 
     setFile(selected);
+  };
+
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    validateAndSetFile(selected);
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragActive(false);
+    const selected = event.dataTransfer.files?.[0];
+    validateAndSetFile(selected);
+  };
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragActive(true);
+  };
+
+  const onDragLeave = () => {
+    setIsDragActive(false);
   };
 
   const clearFile = () => {
@@ -78,7 +99,16 @@ function App() {
       <main className="mx-auto w-full max-w-6xl px-6 py-10">
         <section className="grid gap-6 lg:grid-cols-[1fr_360px]">
           <div className="space-y-4">
-            <div className="rounded-2xl border border-dashed border-white/20 bg-white/5 p-6">
+            <div
+              className={`rounded-2xl border border-dashed p-6 transition ${
+                isDragActive
+                  ? 'border-indigo-400 bg-indigo-500/10'
+                  : 'border-white/20 bg-white/5'
+              }`}
+              onDragOver={onDragOver}
+              onDragLeave={onDragLeave}
+              onDrop={onDrop}
+            >
               <label className="flex flex-col gap-3 text-sm text-slate-200">
                 <span className="text-base font-medium">בחירת קובץ PDF</span>
                 <input
@@ -88,6 +118,9 @@ function App() {
                   className="file:mr-4 file:rounded-xl file:border-0 file:bg-indigo-500 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-indigo-400"
                 />
               </label>
+              <p className="text-xs text-slate-400">
+                אפשר לגרור קובץ לכאן או ללחוץ לבחירה מהמחשב.
+              </p>
               {error ? (
                 <p className="mt-4 rounded-lg border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
                   {error}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,11 @@
-import { type ChangeEvent, type DragEvent, useEffect, useMemo, useState } from 'react';
+import {
+  type ChangeEvent,
+  type DragEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 const MAX_FILE_SIZE_MB = 50;
 
@@ -6,6 +13,7 @@ function App() {
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState('');
   const [isDragActive, setIsDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const fileUrl = useMemo(() => {
     if (!file) {
@@ -58,6 +66,10 @@ function App() {
     validateAndSetFile(selected);
   };
 
+  const openFilePicker = () => {
+    fileInputRef.current?.click();
+  };
+
   const onDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragActive(false);
@@ -99,28 +111,46 @@ function App() {
       <main className="mx-auto w-full max-w-6xl px-6 py-10">
         <section className="grid gap-6 lg:grid-cols-[1fr_360px]">
           <div className="space-y-4">
-            <div
-              className={`rounded-2xl border border-dashed p-6 transition ${
-                isDragActive
-                  ? 'border-indigo-400 bg-indigo-500/10'
-                  : 'border-white/20 bg-white/5'
-              }`}
-              onDragOver={onDragOver}
-              onDragLeave={onDragLeave}
-              onDrop={onDrop}
-            >
-              <label className="flex flex-col gap-3 text-sm text-slate-200">
-                <span className="text-base font-medium">בחירת קובץ PDF</span>
-                <input
-                  type="file"
-                  accept="application/pdf"
-                  onChange={onFileChange}
-                  className="file:mr-4 file:rounded-xl file:border-0 file:bg-indigo-500 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-indigo-400"
-                />
-              </label>
-              <p className="text-xs text-slate-400">
-                אפשר לגרור קובץ לכאן או ללחוץ לבחירה מהמחשב.
-              </p>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+              <div
+                className={`rounded-2xl border border-dashed p-6 transition ${
+                  isDragActive
+                    ? 'border-indigo-400 bg-indigo-500/10'
+                    : 'border-white/20 bg-white/5'
+                }`}
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+                onDrop={onDrop}
+              >
+                <label className="flex flex-col gap-3 text-sm text-slate-200">
+                  <span className="text-base font-medium">בחירת קובץ PDF</span>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="application/pdf"
+                    onChange={onFileChange}
+                    className="file:mr-4 file:rounded-xl file:border-0 file:bg-indigo-500 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-indigo-400"
+                  />
+                </label>
+                <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-400">
+                  <span>אפשר לגרור קובץ לכאן או לבחור מהמחשב.</span>
+                  <button
+                    type="button"
+                    onClick={openFilePicker}
+                    className="rounded-lg border border-white/10 bg-white/10 px-3 py-1 text-xs text-slate-200 transition hover:bg-white/20"
+                  >
+                    בחר קובץ
+                  </button>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-slate-300">
+                <span className="rounded-full bg-white/10 px-3 py-1">
+                  סטטוס מערכת: {file ? 'מציגה קובץ' : 'מוכנה להעלאה'}
+                </span>
+                <span className="text-slate-500">
+                  הקובץ נטען מקומית בלבד — אין העלאה לשרת.
+                </span>
+              </div>
               {error ? (
                 <p className="mt-4 rounded-lg border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
                   {error}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,295 +1,152 @@
-import { useEffect, useState } from 'react';
-import { Toaster } from 'react-hot-toast';
-import { motion } from 'framer-motion';
-import { Timer } from './components/Timer';
-import { Dashboard } from './components/Dashboard';
-import { AddClient } from './components/AddClient';
-import { AudioTranscriber } from './components/AudioTranscriber';
-import { ThemeManager } from './components/ThemeManager';
-import { BackupRestore } from './components/BackupRestore';
-import { ImportExport } from './components/ImportExport';
-import { Clients } from './components/Clients';
-import { TableSelector } from './components/TableSelector';
-import { useStore } from './store/useStore';
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+
+const MAX_FILE_SIZE_MB = 50;
 
 function App() {
-  const { currentTheme, settings } = useStore();
-  const [searchTerm, setSearchTerm] = useState('');
-  const [showQuickTools, setShowQuickTools] = useState(false);
-  const [activeTab, setActiveTab] = useState<'home' | 'clients'>('clients');
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState('');
 
-  // Apply theme on load and changes
+  const fileUrl = useMemo(() => {
+    if (!file) {
+      return '';
+    }
+    return URL.createObjectURL(file);
+  }, [file]);
+
   useEffect(() => {
     const root = document.documentElement;
-    Object.entries(currentTheme.colors).forEach(([key, value]) => {
-      root.style.setProperty(`--color-${key}`, value);
-    });
-    
-    // Apply RTL
     root.setAttribute('dir', 'rtl');
     root.setAttribute('lang', 'he');
-  }, [currentTheme]);
-
-  // Handle ESC key
-  useEffect(() => {
-    let escCount = 0;
-    let escTimer: NodeJS.Timeout;
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        escCount++;
-        
-        if (escCount === 1) {
-          // First ESC - close modals/dropdowns
-          setShowQuickTools(false);
-          setSearchTerm('');
-        } else if (escCount === 2) {
-          // Double ESC - scroll to top
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        }
-        
-        clearTimeout(escTimer);
-        escTimer = setTimeout(() => {
-          escCount = 0;
-        }, 500);
-      }
-    };
-
-    window.addEventListener('keydown', handleEsc);
-    return () => {
-      window.removeEventListener('keydown', handleEsc);
-      clearTimeout(escTimer);
-    };
   }, []);
 
-  // Auto save
   useEffect(() => {
-    const saveInterval = setInterval(() => {
-      console.log('Auto saving...');
-      // The zustand persist middleware handles this automatically
-    }, settings.autoSaveInterval * 1000);
+    return () => {
+      if (fileUrl) {
+        URL.revokeObjectURL(fileUrl);
+      }
+    };
+  }, [fileUrl]);
 
-    return () => clearInterval(saveInterval);
-  }, [settings.autoSaveInterval]);
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    setError('');
+
+    if (!selected) {
+      setFile(null);
+      return;
+    }
+
+    if (selected.type !== 'application/pdf') {
+      setError('אנא בחר קובץ PDF בלבד.');
+      event.target.value = '';
+      setFile(null);
+      return;
+    }
+
+    if (selected.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      setError(`הקובץ גדול מדי. אפשר עד ${MAX_FILE_SIZE_MB}MB.`);
+      event.target.value = '';
+      setFile(null);
+      return;
+    }
+
+    setFile(selected);
+  };
+
+  const clearFile = () => {
+    setFile(null);
+    setError('');
+  };
 
   return (
-    <div 
-      className="min-h-screen w-full transition-colors duration-300"
-      style={{ backgroundColor: currentTheme.colors.background }}
-    >
-      <Toaster
-        position="top-center"
-        reverseOrder={false}
-        toastOptions={{
-          duration: 3000,
-          style: {
-            background: currentTheme.colors.background,
-            color: currentTheme.colors.text,
-            border: `1px solid ${currentTheme.colors.border}`,
-            borderRadius: '12px',
-            padding: '16px',
-          },
-          success: {
-            iconTheme: {
-              primary: currentTheme.colors.success,
-              secondary: currentTheme.colors.background,
-            },
-          },
-          error: {
-            iconTheme: {
-              primary: currentTheme.colors.error,
-              secondary: currentTheme.colors.background,
-            },
-          },
-        }}
-      />
-
-      {/* Header */}
-      <header className="sticky top-0 z-40 backdrop-blur-lg bg-white/80 dark:bg-gray-900/80 border-b border-gray-200 dark:border-gray-700 w-full">
-        <div className="w-full px-4 py-4">
-          <div className="flex items-center justify-between">
-            <motion.h1
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              className="text-3xl font-bold bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent"
-            >
-              ניהול זמן לקוחות
-            </motion.h1>
-
-            <div className="flex items-center gap-4">
-              {/* Navigation Tabs */}
-              <div className="flex items-center gap-2 ml-6">
-                <button
-                  onClick={() => setActiveTab('home')}
-                  className={`px-4 py-2 rounded-lg transition-colors duration-200 ${
-                    activeTab === 'home'
-                      ? 'bg-primary-100 text-primary-700'
-                      : 'text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  דף הבית
-                </button>
-                <button
-                  onClick={() => setActiveTab('clients')}
-                  className={`px-4 py-2 rounded-lg transition-colors duration-200 flex items-center gap-2 ${
-                    activeTab === 'clients'
-                      ? 'bg-primary-100 text-primary-700'
-                      : 'text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  <FaUsers />
-                  לקוחות
-                </button>
-              </div>
-              
-              {/* Search */}
-              <div className="relative">
-                <input
-                  type="text"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="חיפוש..."
-                  className="pl-10 pr-4 py-2 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all duration-200"
-                />
-                <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-              </div>
-
-              {/* Quick Tools */}
-              <div className="relative">
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  onClick={() => setShowQuickTools(!showQuickTools)}
-                  className="p-2 bg-gradient-to-r from-yellow-400 to-orange-500 hover:from-yellow-500 hover:to-orange-600 text-white rounded-xl shadow-lg transition-all duration-200"
-                >
-                  <FaBolt className="w-5 h-5" />
-                </motion.button>
-
-                {showQuickTools && (
-                  <motion.div
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    className="absolute top-full mt-2 left-0 bg-white rounded-xl shadow-2xl border border-gray-200 p-2 min-w-[200px] z-50"
-                  >
-                    <button
-                      onClick={() => {
-                        // Quick action 1
-                        setShowQuickTools(false);
-                      }}
-                      className="w-full text-right px-4 py-2 hover:bg-gray-100 rounded-lg transition-colors duration-150"
-                    >
-                      הוספת לקוח מהיר
-                    </button>
-                    <button
-                      onClick={() => {
-                        // Quick action 2
-                        setShowQuickTools(false);
-                      }}
-                      className="w-full text-right px-4 py-2 hover:bg-gray-100 rounded-lg transition-colors duration-150"
-                    >
-                      ייצוא מהיר
-                    </button>
-                    <button
-                      onClick={() => {
-                        // Quick action 3
-                        setShowQuickTools(false);
-                      }}
-                      className="w-full text-right px-4 py-2 hover:bg-gray-100 rounded-lg transition-colors duration-150"
-                    >
-                      סטטיסטיקות
-                    </button>
-                  </motion.div>
-                )}
-              </div>
-
-              {/* Theme Manager */}
-              <ThemeManager />
-
-              {/* Import/Export */}
-              <ImportExport />
-
-              {/* Backup & Restore */}
-              <BackupRestore />
-            </div>
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-white/10 bg-slate-950/70 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-white">קורא PDF מקומי</h1>
+            <p className="mt-2 text-sm text-slate-300">
+              העלו קובץ PDF וצפו בו ישירות בדפדפן. הקובץ נשאר מקומי אצלכם.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
+            <span className="inline-flex h-3 w-3 rounded-full bg-emerald-400" aria-hidden="true" />
+            שמירה מקומית בלבד
           </div>
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="w-full px-4 py-8">
-        {activeTab === 'home' ? (
-          <div className="grid gap-8">
-            {/* Dashboard Stats */}
-            <motion.section
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1 }}
-            >
-              <Dashboard />
-            </motion.section>
-
-            {/* Timer and Add Client */}
-            <div className="grid md:grid-cols-2 gap-8">
-              <motion.section
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.2 }}
-              >
-                <Timer />
-              </motion.section>
-
-              <motion.section
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.3 }}
-              >
-                <AddClient />
-              </motion.section>
+      <main className="mx-auto w-full max-w-6xl px-6 py-10">
+        <section className="grid gap-6 lg:grid-cols-[1fr_360px]">
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-dashed border-white/20 bg-white/5 p-6">
+              <label className="flex flex-col gap-3 text-sm text-slate-200">
+                <span className="text-base font-medium">בחירת קובץ PDF</span>
+                <input
+                  type="file"
+                  accept="application/pdf"
+                  onChange={onFileChange}
+                  className="file:mr-4 file:rounded-xl file:border-0 file:bg-indigo-500 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-indigo-400"
+                />
+              </label>
+              {error ? (
+                <p className="mt-4 rounded-lg border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                  {error}
+                </p>
+              ) : null}
+              {file ? (
+                <div className="mt-4 flex flex-wrap items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-200">
+                  <span className="font-semibold text-white">{file.name}</span>
+                  <span className="text-xs text-slate-400">
+                    {(file.size / (1024 * 1024)).toFixed(2)}MB
+                  </span>
+                  <button
+                    type="button"
+                    onClick={clearFile}
+                    className="mr-auto rounded-lg border border-white/10 bg-white/10 px-3 py-1 text-xs text-slate-200 transition hover:bg-white/20"
+                  >
+                    הסרת קובץ
+                  </button>
+                </div>
+              ) : null}
             </div>
 
-            {/* Tables Section */}
-            <motion.section
-              initial={{ opacity: 0, y: 20 }}
-              transition={{ delay: 0.4 }}
-              animate={{ opacity: 1, y: 0 }}
-              className="bg-white rounded-2xl shadow-lg p-6"
-            >
-              <h2 className="text-2xl font-bold text-gray-800 mb-6">טבלאות זמן עבודה</h2>
-              <TableSelector />
-            </motion.section>
-
-            {/* Audio Transcriber */}
-            <motion.section
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.5 }}
-              className="bg-white rounded-2xl shadow-lg p-6 mt-8"
-            >
-              <h2 className="text-2xl font-bold text-gray-800 mb-6">תמלול אודיו (Whisper)</h2>
-              <AudioTranscriber />
-            </motion.section>
+            <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+              {fileUrl ? (
+                <iframe
+                  title="PDF Viewer"
+                  src={fileUrl}
+                  className="h-[70vh] w-full"
+                />
+              ) : (
+                <div className="flex h-[70vh] flex-col items-center justify-center gap-4 text-center text-slate-300">
+                  <div className="rounded-full bg-white/10 px-4 py-2 text-sm">אין קובץ להצגה</div>
+                  <p className="max-w-md text-sm">
+                    בחרו קובץ PDF כדי לראות תצוגה מקדימה. תוכלו להגדיל/להקטין בעזרת כלי הדפדפן.
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
-        ) : (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-          >
-            <Clients />
-          </motion.div>
-        )}
+
+          <aside className="space-y-4">
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+              <h2 className="text-lg font-semibold text-white">טיפים לצפייה</h2>
+              <ul className="mt-4 space-y-3 text-sm text-slate-300">
+                <li>פתחו קבצים מהתיקייה המקומית — אין העלאה לשרת.</li>
+                <li>אפשר לגרור את ה-PDF ישירות על אזור הבחירה.</li>
+                <li>השתמשו בחיפוש המובנה בדפדפן כדי לאתר מילים.</li>
+              </ul>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-300">
+              <p className="font-semibold text-white">פורמטים נתמכים</p>
+              <p className="mt-2">PDF בלבד, עד {MAX_FILE_SIZE_MB}MB לכל קובץ.</p>
+            </div>
+          </aside>
+        </section>
       </main>
 
-      {/* Footer */}
-      <footer className="mt-16 border-t border-gray-200 dark:border-gray-700 w-full">
-        <div className="w-full px-4 py-6">
-          <div className="text-center text-gray-600 dark:text-gray-400">
-            <p>מערכת ניהול זמן לקוחות מתקדמת © 2024</p>
-            <p className="text-sm mt-2">
-              לחץ ESC פעם אחת לסגירת חלונות | לחץ ESC פעמיים לגלילה למעלה
-            </p>
-          </div>
-        </div>
+      <footer className="border-t border-white/10 py-6 text-center text-xs text-slate-500">
+        נבנה לצפייה מהירה במסמכים — ללא שמירה או העלאה של קבצים.
       </footer>
     </div>
   );


### PR DESCRIPTION
### Motivation

- Replace the large dashboard app with a focused local PDF reader UI so users can open and preview PDF files in the browser.
- Provide client-side file validation and privacy reassurance that files stay local and are not uploaded.
- Simplify the app surface by removing unrelated dashboard components and enforcing RTL layout for Hebrew use.

### Description

- Replaced `src/App.tsx` contents with a local PDF reader layout that includes a file picker, preview iframe, tips pane, and footer message.
- Added client-side validation: only `application/pdf` is accepted and files are limited to `MAX_FILE_SIZE_MB = 50` MB, with user-facing error messages and a `clearFile` action.
- Use `URL.createObjectURL` for preview and `URL.revokeObjectURL` cleanup, and set `dir="rtl"` and `lang="he"` on the document root.
- Small TypeScript change to imports: `import { type ChangeEvent, useEffect, useMemo, useState }` and use `ChangeEvent<HTMLInputElement>` for the file input handler.

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, Vite reported ready (note: `xdg-open` ENOENT warning when trying to auto-open a browser, but server served successfully).
- Ran a Playwright script to load the app and capture a screenshot (`artifacts/pdf-reader-home.png`) and the script completed successfully.
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d50e4211483218bfb01decd57f138)